### PR TITLE
Grid-following inverter model

### DIFF
--- a/ModPowerSystems/EmtThreePhase/Control/InverterPQCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/InverterPQCtrl.mo
@@ -11,13 +11,14 @@ block InverterPQCtrl
     Placement(visible = true, transformation(origin = {65, -1}, extent = {{-21, -21}, {21, 21}}, rotation = 0)));
   parameter Real P_ref=500;
   parameter Real Q_ref=200;
+  parameter Real omega_nom;
   Modelica.Blocks.Interfaces.RealInput theta annotation(
     Placement(visible = true, transformation(origin = {-120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   ModPowerSystems.EmtThreePhase.Transforms.ABCtoDQ0_Park aBCtoDQ0_Park1 annotation(
     Placement(visible = true, transformation(origin = {-58, 42}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   ModPowerSystems.EmtThreePhase.Transforms.ABCtoDQ0_Park aBCtoDQ0_Park2 annotation(
     Placement(visible = true, transformation(origin = {-56, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref) annotation(
+  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref, omega_nom = omega_nom) annotation(
     Placement(visible = true, transformation(origin = { -1, 45}, extent = {{-21, -21}, {21, 21}}, rotation = 0)));
 equation
   connect(aBCtoDQ0_Park2.f_dq, currentCtrl1.I_dq) annotation(

--- a/ModPowerSystems/EmtThreePhase/Control/InverterPQCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/InverterPQCtrl.mo
@@ -9,15 +9,15 @@ block InverterPQCtrl
     Placement(visible = true, transformation(origin = {-120, -22}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, -22}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   ModPowerSystems.EmtThreePhase.Control.CurrentCtrl currentCtrl1 annotation(
     Placement(visible = true, transformation(origin = {65, -1}, extent = {{-21, -21}, {21, 21}}, rotation = 0)));
-  inner parameter Real P_ref=500;
-  inner parameter Real Q_ref=200;
+  parameter Real P_ref=500;
+  parameter Real Q_ref=200;
   Modelica.Blocks.Interfaces.RealInput theta annotation(
     Placement(visible = true, transformation(origin = {-120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 20}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
   ModPowerSystems.EmtThreePhase.Transforms.ABCtoDQ0_Park aBCtoDQ0_Park1 annotation(
     Placement(visible = true, transformation(origin = {-58, 42}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   ModPowerSystems.EmtThreePhase.Transforms.ABCtoDQ0_Park aBCtoDQ0_Park2 annotation(
     Placement(visible = true, transformation(origin = {-56, -68}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1 annotation(
+  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref) annotation(
     Placement(visible = true, transformation(origin = { -1, 45}, extent = {{-21, -21}, {21, 21}}, rotation = 0)));
 equation
   connect(aBCtoDQ0_Park2.f_dq, currentCtrl1.I_dq) annotation(

--- a/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
@@ -5,8 +5,8 @@ block PQInverterControl
   parameter Real K_pll_i=2 "PLL integral gain";
   parameter Real K_pll_d=1 "PLL derivative gain";
   parameter Real f_nominal=50 "nominal frequency";
-  inner parameter Real P_ref=500;
-  inner parameter Real Q_ref=200;
+  parameter Real P_ref=500;
+  parameter Real Q_ref=200;
   ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref)  annotation(
     Placement(visible = true, transformation(origin = {-11, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
   inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, f_nom = f_nominal) annotation(

--- a/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
@@ -8,9 +8,7 @@ block PQInverterControl
   inner parameter Real P_ref=500;
   inner parameter Real Q_ref=200;
   ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1  annotation(
-    Placement(visible = true, transformation(origin = {9, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealOutput V_dq_con[2] annotation(
-    Placement(visible = true, transformation(origin = {108, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {108, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    Placement(visible = true, transformation(origin = {-11, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
   inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, f_nom = f_nominal) annotation(
     Placement(visible = true, transformation(origin = {-82, 11}, extent = {{-10, -11}, {10, 11}}, rotation = 0)));
   Modelica.Blocks.Interfaces.RealInput V_in[3] annotation(
@@ -21,35 +19,39 @@ block PQInverterControl
     Placement(visible = true, transformation(origin = {-45, -61}, extent = {{-7, -7}, {7, 7}}, rotation = 0)));
   Transforms.ABCtoDQ0_Park aBCtoDQ0_Park1 annotation(
     Placement(visible = true, transformation(origin = {-45, 45}, extent = {{-7, -7}, {7, 7}}, rotation = 0)));
-  CurrentCtrl currentCtrl1 annotation(
-    Placement(visible = true, transformation(origin = {62, 1.77636e-15}, extent = {{-14, -14}, {14, 14}}, rotation = 0)));
-  Modelica.Blocks.Interfaces.RealOutput theta annotation(
-    Placement(visible = true, transformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90), iconTransformation(origin = {106, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  ModPowerSystems.EmtThreePhase.Control.CurrentCtrl currentCtrl1 annotation(
+    Placement(visible = true, transformation(origin = {36, 1.77636e-15}, extent = {{-14, -14}, {14, 14}}, rotation = 0)));
+  ModPowerSystems.EmtThreePhase.Transforms.DQtoABC_Park dQtoABC_Park annotation(
+    Placement(visible = true, transformation(origin = {72, 5.55112e-16}, extent = {{-8, -8}, {8, 8}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput V_out[3] annotation(
+    Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {100, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
   connect(aBCtoDQ0_Park2.f_dq, powerCtrl1.I_dq) annotation(
-    Line(points = {{-37, -61}, {-34, -61}, {-34, 10}, {-7, 10}}, color = {0, 0, 127}, thickness = 0.5));
-  connect(pll1.theta, theta) annotation(
-    Line(points = {{-71, 11}, {-64, 11}, {-64, -88}, {0, -88}, {0, -110}}, color = {0, 0, 127}));
+    Line(points = {{-37, -61}, {-34, -61}, {-34, 10}, {-27, 10}}, color = {0, 0, 127}, thickness = 0.5));
   connect(powerCtrl1.I_inv_q_con, currentCtrl1.I_inv_q_con) annotation(
-    Line(points = {{23, 11}, {32, 11}, {32, -2}, {46, -2}}, color = {0, 0, 127}));
+    Line(points = {{3, 11}, {10, 11}, {10, -3}, {19, -3}}, color = {0, 0, 127}));
   connect(I_in, aBCtoDQ0_Park2.f_abc) annotation(
     Line(points = {{-120, -22}, {-45, -22}, {-45, -53}}, color = {0, 0, 127}, thickness = 0.5));
   connect(pll1.theta, aBCtoDQ0_Park2.theta) annotation(
     Line(points = {{-71, 11}, {-58, 11}, {-58, -60}, {-52, -60}}, color = {0, 0, 127}));
-  connect(currentCtrl1.V_dq_con, V_dq_con) annotation(
-    Line(points = {{77, 0}, {108, 0}}, color = {0, 0, 127}, thickness = 0.5));
   connect(aBCtoDQ0_Park2.f_dq, currentCtrl1.I_dq) annotation(
-    Line(points = {{-37, -61}, {62, -61}, {62, -15}}, color = {0, 0, 127}, thickness = 0.5));
+    Line(points = {{-37, -61}, {36, -61}, {36, -15}}, color = {0, 0, 127}, thickness = 0.5));
   connect(V_in, pll1.V_abc) annotation(
     Line(points = {{-120, 62}, {-100, 62}, {-100, 11}, {-94, 11}}, color = {0, 0, 127}, thickness = 0.5));
   connect(powerCtrl1.I_inv_d_con, currentCtrl1.I_inv_d_con) annotation(
-    Line(points = {{23, 14}, {36, 14}, {36, 2}, {46, 2}}, color = {0, 0, 127}));
+    Line(points = {{3, 14}, {14, 14}, {14, 3}, {19, 3}}, color = {0, 0, 127}));
   connect(aBCtoDQ0_Park1.f_dq, powerCtrl1.V_dq) annotation(
-    Line(points = {{-37, 45}, {-20, 45}, {-20, 16}, {-6, 16}}, color = {0, 0, 127}, thickness = 0.5));
+    Line(points = {{-37, 45}, {-34, 45}, {-34, 16}, {-27, 16}}, color = {0, 0, 127}, thickness = 0.5));
   connect(pll1.theta, aBCtoDQ0_Park1.theta) annotation(
     Line(points = {{-71, 11}, {-58, 11}, {-58, 46}, {-52, 46}}, color = {0, 0, 127}));
   connect(V_in, aBCtoDQ0_Park1.f_abc) annotation(
     Line(points = {{-120, 62}, {-45, 62}, {-45, 53}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(currentCtrl1.V_dq_con, dQtoABC_Park.v_dq) annotation(
+    Line(points = {{52, 0}, {62, 0}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(dQtoABC_Park.v_abc, V_out) annotation(
+    Line(points = {{81, 0}, {110, 0}}, color = {0, 0, 127}));
+  connect(pll1.theta, dQtoABC_Park.theta) annotation(
+    Line(points = {{-71, 11}, {-66, 11}, {-66, 76}, {72, 76}, {72, 10}}, color = {0, 0, 127}));
   annotation(
     Icon(coordinateSystem(initialScale = 0.1), graphics = {Text(origin = {-2, 81}, extent = {{-50, 23}, {50, -23}}, textString = "Inverter"), Text(origin = {-14, 56}, extent = {{-84, 14}, {102, -24}}, textString = "Control"), Text(origin = {-32, 26}, extent = {{-48, 12}, {104, -30}}, textString = "(PQ)"), Rectangle(extent = {{-100, 100}, {100, -100}}), Rectangle(origin = {-39, -42}, extent = {{-31, 18}, {31, -18}}), Text(origin = {-39, -39}, extent = {{-19, 9}, {19, -9}}, textString = "power"), Rectangle(origin = {45, -42}, extent = {{-31, 18}, {31, -18}}), Text(origin = {45, -39}, extent = {{-19, 9}, {19, -9}}, textString = "current"), Line(origin = {-82.2, -41.6}, points = {{-11, 0}, {11, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {1.8, -41.6}, points = {{-11, 0}, {11, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {83.8, -41.6}, points = {{-9, 0}, {9, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {-1.2, -58.6}, points = {{80, 17}, {80, -17}, {-80, -17}, {-80, 17}}, arrow = {Arrow.None, Arrow.Open}), Text(origin = {84, -34}, extent = {{-8, 8}, {8, -8}}, textString = "v", textStyle = {TextStyle.Italic})}),
   Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">parametrized following ssmd [1], based on commit&nbsp;<span style=\"color: rgb(46, 46, 46); font-family: Menlo, 'DejaVu Sans Mono', 'Liberation Mono', Consolas, 'Ubuntu Mono', 'Courier New', 'andale mono', 'lucida console', monospace; font-size: 14px; orphans: 2; white-space: nowrap; widows: 2; background-color: rgb(250, 250, 250);\">d675e1ff</span>&nbsp;&nbsp;.</div><div style=\"font-size: 12px;\">equations refered to [2].<br><div><br></div><div>[1]&nbsp;<a href=\"https://git.rwth-aachen.de/acs/public/simulation/ssmd\">https://git.rwth-aachen.de/acs/public/simulation/ssmd</a></div></div><span style=\"font-size: 12px;\">[2] A. Angioni, E. De Din et el., \"A state-space model for distribution networks\"</span></body></html>"));

--- a/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
@@ -1,0 +1,56 @@
+within ModPowerSystems.EmtThreePhase.Control;
+
+block PQInverterControl
+  parameter Real K_pll_p=0.25 "PLL proportional gain";
+  parameter Real K_pll_i=2 "PLL integral gain";
+  parameter Real K_pll_d=1 "PLL derivative gain";
+  parameter Real f_nominal=50 "nominal frequency";
+  inner parameter Real P_ref=500;
+  inner parameter Real Q_ref=200;
+  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1  annotation(
+    Placement(visible = true, transformation(origin = {9, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput V_dq_con[2] annotation(
+    Placement(visible = true, transformation(origin = {108, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {108, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, f_nom = f_nominal) annotation(
+    Placement(visible = true, transformation(origin = {-82, 11}, extent = {{-10, -11}, {10, 11}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput V_in[3] annotation(
+    Placement(visible = true, transformation(origin = {-120, 62}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 62}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealInput I_in[3] annotation(
+    Placement(visible = true, transformation(origin = {-120, -22}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, -22}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));
+  Transforms.ABCtoDQ0_Park aBCtoDQ0_Park2 annotation(
+    Placement(visible = true, transformation(origin = {-45, -61}, extent = {{-7, -7}, {7, 7}}, rotation = 0)));
+  Transforms.ABCtoDQ0_Park aBCtoDQ0_Park1 annotation(
+    Placement(visible = true, transformation(origin = {-45, 45}, extent = {{-7, -7}, {7, 7}}, rotation = 0)));
+  CurrentCtrl currentCtrl1 annotation(
+    Placement(visible = true, transformation(origin = {62, 1.77636e-15}, extent = {{-14, -14}, {14, 14}}, rotation = 0)));
+  Modelica.Blocks.Interfaces.RealOutput theta annotation(
+    Placement(visible = true, transformation(origin = {0, -110}, extent = {{-10, -10}, {10, 10}}, rotation = -90), iconTransformation(origin = {106, -34}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(aBCtoDQ0_Park2.f_dq, powerCtrl1.I_dq) annotation(
+    Line(points = {{-37, -61}, {-34, -61}, {-34, 10}, {-7, 10}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(pll1.theta, theta) annotation(
+    Line(points = {{-71, 11}, {-64, 11}, {-64, -88}, {0, -88}, {0, -110}}, color = {0, 0, 127}));
+  connect(powerCtrl1.I_inv_q_con, currentCtrl1.I_inv_q_con) annotation(
+    Line(points = {{23, 11}, {32, 11}, {32, -2}, {46, -2}}, color = {0, 0, 127}));
+  connect(I_in, aBCtoDQ0_Park2.f_abc) annotation(
+    Line(points = {{-120, -22}, {-45, -22}, {-45, -53}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(pll1.theta, aBCtoDQ0_Park2.theta) annotation(
+    Line(points = {{-71, 11}, {-58, 11}, {-58, -60}, {-52, -60}}, color = {0, 0, 127}));
+  connect(currentCtrl1.V_dq_con, V_dq_con) annotation(
+    Line(points = {{77, 0}, {108, 0}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(aBCtoDQ0_Park2.f_dq, currentCtrl1.I_dq) annotation(
+    Line(points = {{-37, -61}, {62, -61}, {62, -15}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(V_in, pll1.V_abc) annotation(
+    Line(points = {{-120, 62}, {-100, 62}, {-100, 11}, {-94, 11}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(powerCtrl1.I_inv_d_con, currentCtrl1.I_inv_d_con) annotation(
+    Line(points = {{23, 14}, {36, 14}, {36, 2}, {46, 2}}, color = {0, 0, 127}));
+  connect(aBCtoDQ0_Park1.f_dq, powerCtrl1.V_dq) annotation(
+    Line(points = {{-37, 45}, {-20, 45}, {-20, 16}, {-6, 16}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(pll1.theta, aBCtoDQ0_Park1.theta) annotation(
+    Line(points = {{-71, 11}, {-58, 11}, {-58, 46}, {-52, 46}}, color = {0, 0, 127}));
+  connect(V_in, aBCtoDQ0_Park1.f_abc) annotation(
+    Line(points = {{-120, 62}, {-45, 62}, {-45, 53}}, color = {0, 0, 127}, thickness = 0.5));
+  annotation(
+    Icon(coordinateSystem(initialScale = 0.1), graphics = {Text(origin = {-2, 81}, extent = {{-50, 23}, {50, -23}}, textString = "Inverter"), Text(origin = {-14, 56}, extent = {{-84, 14}, {102, -24}}, textString = "Control"), Text(origin = {-32, 26}, extent = {{-48, 12}, {104, -30}}, textString = "(PQ)"), Rectangle(extent = {{-100, 100}, {100, -100}}), Rectangle(origin = {-39, -42}, extent = {{-31, 18}, {31, -18}}), Text(origin = {-39, -39}, extent = {{-19, 9}, {19, -9}}, textString = "power"), Rectangle(origin = {45, -42}, extent = {{-31, 18}, {31, -18}}), Text(origin = {45, -39}, extent = {{-19, 9}, {19, -9}}, textString = "current"), Line(origin = {-82.2, -41.6}, points = {{-11, 0}, {11, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {1.8, -41.6}, points = {{-11, 0}, {11, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {83.8, -41.6}, points = {{-9, 0}, {9, 0}}, arrow = {Arrow.None, Arrow.Open}), Line(origin = {-1.2, -58.6}, points = {{80, 17}, {80, -17}, {-80, -17}, {-80, 17}}, arrow = {Arrow.None, Arrow.Open}), Text(origin = {84, -34}, extent = {{-8, 8}, {8, -8}}, textString = "v", textStyle = {TextStyle.Italic})}),
+  Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">parametrized following ssmd [1], based on commit&nbsp;<span style=\"color: rgb(46, 46, 46); font-family: Menlo, 'DejaVu Sans Mono', 'Liberation Mono', Consolas, 'Ubuntu Mono', 'Courier New', 'andale mono', 'lucida console', monospace; font-size: 14px; orphans: 2; white-space: nowrap; widows: 2; background-color: rgb(250, 250, 250);\">d675e1ff</span>&nbsp;&nbsp;.</div><div style=\"font-size: 12px;\">equations refered to [2].<br><div><br></div><div>[1]&nbsp;<a href=\"https://git.rwth-aachen.de/acs/public/simulation/ssmd\">https://git.rwth-aachen.de/acs/public/simulation/ssmd</a></div></div><span style=\"font-size: 12px;\">[2] A. Angioni, E. De Din et el., \"A state-space model for distribution networks\"</span></body></html>"));
+end PQInverterControl;

--- a/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
@@ -7,9 +7,10 @@ block PQInverterControl
   parameter Real f_nominal=50 "nominal frequency";
   parameter Real P_ref=500;
   parameter Real Q_ref=200;
-  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref)  annotation(
+  parameter Real omega_nom = 2*pi*f_nominal;
+  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref, omega_nom = omega_nom)  annotation(
     Placement(visible = true, transformation(origin = {-11, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
-  inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, f_nom = f_nominal) annotation(
+  ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, omega_nom = omega_nom) annotation(
     Placement(visible = true, transformation(origin = {-82, 11}, extent = {{-10, -11}, {10, 11}}, rotation = 0)));
   Modelica.Blocks.Interfaces.RealInput V_in[3] annotation(
     Placement(visible = true, transformation(origin = {-120, 62}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-120, 62}, extent = {{-20, -20}, {20, 20}}, rotation = 0)));

--- a/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PQInverterControl.mo
@@ -7,7 +7,7 @@ block PQInverterControl
   parameter Real f_nominal=50 "nominal frequency";
   inner parameter Real P_ref=500;
   inner parameter Real Q_ref=200;
-  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1  annotation(
+  ModPowerSystems.EmtThreePhase.Control.PowerCtrl powerCtrl1(P_ref=P_ref,Q_ref=Q_ref)  annotation(
     Placement(visible = true, transformation(origin = {-11, 13}, extent = {{-13, -13}, {13, 13}}, rotation = 0)));
   inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(Kd_pll = K_pll_d, Ki_pll = K_pll_i, Kp_pll = K_pll_p, f_nom = f_nominal) annotation(
     Placement(visible = true, transformation(origin = {-82, 11}, extent = {{-10, -11}, {10, 11}}, rotation = 0)));

--- a/ModPowerSystems/EmtThreePhase/Control/PowerCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PowerCtrl.mo
@@ -10,6 +10,8 @@ block PowerCtrl
   Modelica.Blocks.Interfaces.RealOutput I_inv_q_con annotation(
     Placement(visible = true, transformation(origin = {108, -14}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {108, -14}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   
+  parameter Real omega_nom;
+  
   // low-pass filtered power input
   Real P;
   Real Q;
@@ -33,7 +35,7 @@ block PowerCtrl
    Real V_d;
    Real V_q;
    
-  outer ModPowerSystems.EmtThreePhase.Measurements.PLL pll1;
+   
 
 equation
   V_d = V_dq[1];
@@ -41,38 +43,16 @@ equation
   I_d = I_dq[1];
   I_q = I_dq[2];
   
-  // calculating power with dq frame values, use (1)
-  // or with inst values, use (2)
-  
-  //****************************************(1)*********************************************
+  // calculating power with dq frame values
   //power input after Low-Pass Filter, eq. 4 and 5 of [2]
-  der(P) = (-1 * P * pll1.omega_nom) 
+  der(P) = (-1 * P * omega_nom) 
           + (3 / 2)
-          * pll1.omega_nom
+          * omega_nom
           * (V_d * I_d + V_q * I_q);
-  der(Q) = (-1 * Q * pll1.omega_nom) 
+  der(Q) = (-1 * Q * omega_nom) 
           + (3 / 2) 
-          * pll1.omega_nom
+          * omega_nom
           * (V_q * I_d - V_d * I_q);
-  //****************************************(1)*********************************************
-
-  //****************************************(2)*********************************************
-  /*
-  der(P)=-1*P*pll1.omega_nom
-           + (3/2) * pll1.omega_nom
-           * ( pll1.V_abc[1] * I_abc[1]
-           + pll1.V_abc[2] * I_abc[2] 
-           + pll1.V_abc[3] * I_abc[3]);
-  */
-  
-  /*
-  der(Q)= -1 * Q * pll1.omega_nom
-           + (3/2) * pll1.omega_nom * (1/sqrt(3))
-           * ((pll1.V_abc[2] - pll1.V_abc[3]) * I_abc[1]
-           - (pll1.V_abc[3] - pll1.V_abc[1]) * I_abc[2]
-           - (pll1.V_abc[1] - pll1.V_abc[2]) * I_abc[3]);
-  */
-  //****************************************(2)*********************************************
 
   // eq. 6 and 7 of [2]
   der(phi_d) = P_ref - P;

--- a/ModPowerSystems/EmtThreePhase/Control/PowerCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Control/PowerCtrl.mo
@@ -19,8 +19,8 @@ block PowerCtrl
   Real phi_q;
 
   // objective P,Q values
-  outer parameter Real P_ref;
-  outer parameter Real Q_ref;
+  parameter Real P_ref;
+  parameter Real Q_ref;
 
   // inner PI controller parameters
   parameter Real Kp_vd=0.001;

--- a/ModPowerSystems/EmtThreePhase/Control/package.order
+++ b/ModPowerSystems/EmtThreePhase/Control/package.order
@@ -3,3 +3,4 @@ PowerCtrl
 CurrentCtrl
 InverterPQCtrl
 DistributedCtrl
+PQInverterControl

--- a/ModPowerSystems/EmtThreePhase/Converters/InverterPQCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Converters/InverterPQCtrl.mo
@@ -9,6 +9,7 @@ model InverterPQCtrl
     parameter Real P_obj=4e3 "objective Active Power";
     parameter Real Q_obj=4e2 "objective Reactive Power";
     parameter Real f_nominal=50 "nominal frequency";
+    parameter Real omega_nom = 2*pi*f_nominal;
     parameter Real K_pll_p=0.25 "PLL proportional gain";
     parameter Real K_pll_i=2 "PLL integral gain";
     parameter Real K_pll_d=1 "PLL derivative gain";
@@ -24,11 +25,11 @@ model InverterPQCtrl
       Placement(visible = true, transformation(origin = {-14, -10}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
     ModPowerSystems.EmtThreePhase.Measurements.VoltageMeasurementABC voltageMeasurementABC1 annotation(
       Placement(visible = true, transformation(origin = {-14, 34}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
-    inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(f_nom=f_nominal,Kp_pll=K_pll_p,Ki_pll=K_pll_i,Kd_pll=K_pll_d) annotation(
+    inner ModPowerSystems.EmtThreePhase.Measurements.PLL pll1(omega_nom=omega_nom,Kp_pll=K_pll_p,Ki_pll=K_pll_i,Kd_pll=K_pll_d) annotation(
       Placement(visible = true, transformation(origin = {64, 76}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
     ModPowerSystems.EmtThreePhase.Basics.VCVS_DQ vCVS_Inv_Av1(Vnom = V_nominal) annotation(
       Placement(visible = true, transformation(origin = {-66, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
-    ModPowerSystems.EmtThreePhase.Control.InverterPQCtrl inv_PQ_Controller1(P_ref = P_obj, Q_ref = Q_obj) annotation(
+    ModPowerSystems.EmtThreePhase.Control.InverterPQCtrl inv_PQ_Controller1(P_ref = P_obj, Q_ref = Q_obj, omega_nom = omega_nom) annotation(
       Placement(visible = true, transformation(origin = {-42, 76}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
   equation
     connect(voltageMeasurementABC1.v_abc, inv_PQ_Controller1.V_in) annotation(

--- a/ModPowerSystems/EmtThreePhase/Converters/PQInverter.mo
+++ b/ModPowerSystems/EmtThreePhase/Converters/PQInverter.mo
@@ -1,0 +1,52 @@
+within ModPowerSystems.EmtThreePhase.Converters;
+
+model PQInverter
+    extends ModPowerSystems.Base.Interfaces.RealValue.ThreePhase.TwoPin;
+    outer ModPowerSystems.Base.System system;
+    parameter Real L_lc_filter[3,3] = {{3e-2, 0, 0}, {0, 3e-2, 0}, {0, 0, 3e-2}} "Inductance of LC filter";
+    parameter Real C_lc_filter[3,3] = {{1e-6,0,0}, {0,1e-6,0}, {0,0,1e-6}} "Capacitance of LC filter";
+    parameter Real V_nominal = 380 "Nominal voltage";
+    parameter Real P_obj=4e3 "objective Active Power";
+    parameter Real Q_obj=4e2 "objective Reactive Power";      
+  
+    ModPowerSystems.EmtThreePhase.Measurements.CurrentMeasurementABC currentMeasurementABC1 annotation(
+      Placement(visible = true, transformation(origin = {22, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    ModPowerSystems.EmtThreePhase.Basics.Ground ground2 annotation(
+      Placement(visible = true, transformation(origin = {-14, -36}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    ModPowerSystems.EmtThreePhase.Basics.Inductor inductor1(L = L_lc_filter) annotation(
+      Placement(visible = true, transformation(origin = {-34, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+    ModPowerSystems.EmtThreePhase.Basics.Capacitor capacitor1(C = C_lc_filter) annotation(
+      Placement(visible = true, transformation(origin = {-14, -10}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
+    ModPowerSystems.EmtThreePhase.Measurements.VoltageMeasurementABC voltageMeasurementABC1 annotation(
+      Placement(visible = true, transformation(origin = {-14, 34}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
+    ModPowerSystems.EmtThreePhase.Basics.VCVS_DQ vCVS_Inv_Av1(Vnom = V_nominal) annotation(
+      Placement(visible = true, transformation(origin = {-66, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
+    ModPowerSystems.EmtThreePhase.Control.PQInverterControl pQInverterControl(P_ref = P_obj, Q_ref = Q_obj) annotation(
+    Placement(visible = true, transformation(origin = {-16, 76}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
+equation
+  connect(currentMeasurementABC1.Plug2, Plug2) annotation(
+    Line(points = {{32, 0}, {100, 0}}));
+  connect(capacitor1.Plug1, currentMeasurementABC1.Plug1) annotation(
+    Line(points = {{-14, 0}, {12, 0}}));
+  connect(vCVS_Inv_Av1.Plug2, Plug1) annotation(
+    Line(points = {{-76, 0}, {-100, 0}}));
+  connect(vCVS_Inv_Av1.Plug1, inductor1.Plug1) annotation(
+    Line(points = {{-56, 0}, {-44, 0}, {-44, 0}, {-44, 0}}));
+  connect(voltageMeasurementABC1.Plug1, capacitor1.Plug1) annotation(
+    Line(points = {{-14, 24}, {-14, 0}}));
+  connect(capacitor1.Plug2, ground2.Plug1) annotation(
+    Line(points = {{-14, -20}, {-13, -20}, {-13, -20}, {-14, -20}, {-14, -26}, {-13, -26}, {-13, -26}, {-14, -26}}));
+  connect(inductor1.Plug2, capacitor1.Plug1) annotation(
+    Line(points = {{-24, 0}, {-14, 0}, {-14, 0}, {-14, 0}}));
+  connect(voltageMeasurementABC1.v_abc, pQInverterControl.V_in) annotation(
+    Line(points = {{2, 34}, {10, 34}, {10, 82}, {-4, 82}}, color = {0, 0, 127}));
+  connect(currentMeasurementABC1.i_abc, pQInverterControl.I_in) annotation(
+    Line(points = {{32, -2}, {36, -2}, {36, 74}, {-4, 74}}, color = {0, 0, 127}));
+  connect(pQInverterControl.theta, vCVS_Inv_Av1.theta) annotation(
+    Line(points = {{-26, 72}, {-72, 72}, {-72, 12}}, color = {0, 0, 127}));
+  connect(pQInverterControl.V_dq_con, vCVS_Inv_Av1.V_dq_in) annotation(
+    Line(points = {{-26, 76}, {-66, 76}, {-66, 12}}, color = {0, 0, 127}));
+  annotation(
+      Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">inputs to VCVS_inv:</div><div style=\"font-size: 12px;\">* V_dq;</div><div style=\"font-size: 12px;\">*theta;</div><div style=\"font-size: 12px;\"><br></div><span style=\"font-size: 12px;\">the V_dq and theta input to VCVS are both constants.</span></body></html>"),
+      Icon(graphics = {Ellipse(origin = {-55, -2}, extent = {{-27, 26}, {27, -26}}), Line(origin = {-15.52, 1.21}, points = {{-12.8536, -1.20711}, {-12.8536, -1.20711}, {15.1464, -1.20711}, {15.1464, -1.20711}}, thickness = 1), Rectangle(origin = {30, -1}, lineThickness = 0.75, extent = {{-30, 15}, {30, -15}}), Text(origin = {32, -2}, extent = {{-38, 16}, {38, -16}}, textString = "LC"), Line(origin = {79, 0}, points = {{-19, 0}, {19, 0}, {19, 0}}, thickness = 0.75), Line(origin = {-80.8489, -0.170593}, points = {{-19, 0}, {-1, 0}, {-1, 0}}, thickness = 0.75), Rectangle(origin = {54, 56}, lineThickness = 0.5, extent = {{-18, 14}, {12, -8}}), Text(origin = {55, 58}, extent = {{-13, 10}, {7, -6}}, textString = "PLL"), Rectangle(origin = {-20, 58}, extent = {{-70, 10}, {42, -10}}), Text(origin = {-32, 55}, extent = {{-72, 9}, {58, -3}}, textString = "CONTROLLER"), Line(origin = {73, 29}, points = {{7, -29}, {7, 29}, {-7, 29}}, arrow = {Arrow.None, Arrow.Filled}), Line(origin = {29, 58}, points = {{7, 0}, {-7, 0}}, arrow = {Arrow.None, Arrow.Filled}), Line(origin = {-58, 36}, rotation = 180, points = {{0, 12}, {0, -12}, {0, -12}}, thickness = 0.75, arrow = {Arrow.Filled, Arrow.None}), Rectangle(origin = {0, 20}, extent = {{-100, 60}, {100, -60}}), Text(origin = {0, -68}, extent = {{-60, 16}, {60, -16}}, textString = "%name")}, coordinateSystem(initialScale = 0.1)));
+  end PQInverter;

--- a/ModPowerSystems/EmtThreePhase/Converters/PQInverter.mo
+++ b/ModPowerSystems/EmtThreePhase/Converters/PQInverter.mo
@@ -19,19 +19,15 @@ model PQInverter
       Placement(visible = true, transformation(origin = {-14, -10}, extent = {{-10, -10}, {10, 10}}, rotation = -90)));
     ModPowerSystems.EmtThreePhase.Measurements.VoltageMeasurementABC voltageMeasurementABC1 annotation(
       Placement(visible = true, transformation(origin = {-14, 34}, extent = {{-10, 10}, {10, -10}}, rotation = 0)));
-    ModPowerSystems.EmtThreePhase.Basics.VCVS_DQ vCVS_Inv_Av1(Vnom = V_nominal) annotation(
-      Placement(visible = true, transformation(origin = {-66, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
     ModPowerSystems.EmtThreePhase.Control.PQInverterControl pQInverterControl(P_ref = P_obj, Q_ref = Q_obj) annotation(
     Placement(visible = true, transformation(origin = {-16, 76}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
+  ModPowerSystems.EmtThreePhase.Basics.VCVS vcvs annotation(
+    Placement(visible = true, transformation(origin = {-70, 0}, extent = {{10, -10}, {-10, 10}}, rotation = 0)));
 equation
   connect(currentMeasurementABC1.Plug2, Plug2) annotation(
     Line(points = {{32, 0}, {100, 0}}));
   connect(capacitor1.Plug1, currentMeasurementABC1.Plug1) annotation(
     Line(points = {{-14, 0}, {12, 0}}));
-  connect(vCVS_Inv_Av1.Plug2, Plug1) annotation(
-    Line(points = {{-76, 0}, {-100, 0}}));
-  connect(vCVS_Inv_Av1.Plug1, inductor1.Plug1) annotation(
-    Line(points = {{-56, 0}, {-44, 0}, {-44, 0}, {-44, 0}}));
   connect(voltageMeasurementABC1.Plug1, capacitor1.Plug1) annotation(
     Line(points = {{-14, 24}, {-14, 0}}));
   connect(capacitor1.Plug2, ground2.Plug1) annotation(
@@ -42,10 +38,12 @@ equation
     Line(points = {{2, 34}, {10, 34}, {10, 82}, {-4, 82}}, color = {0, 0, 127}));
   connect(currentMeasurementABC1.i_abc, pQInverterControl.I_in) annotation(
     Line(points = {{32, -2}, {36, -2}, {36, 74}, {-4, 74}}, color = {0, 0, 127}));
-  connect(pQInverterControl.theta, vCVS_Inv_Av1.theta) annotation(
-    Line(points = {{-26, 72}, {-72, 72}, {-72, 12}}, color = {0, 0, 127}));
-  connect(pQInverterControl.V_dq_con, vCVS_Inv_Av1.V_dq_in) annotation(
-    Line(points = {{-26, 76}, {-66, 76}, {-66, 12}}, color = {0, 0, 127}));
+  connect(pQInverterControl.V_out, vcvs.Vin) annotation(
+    Line(points = {{-26, 76}, {-70, 76}, {-70, 12}}, color = {0, 0, 127}, thickness = 0.5));
+  connect(vcvs.Plug2, Plug1) annotation(
+    Line(points = {{-80, 0}, {-100, 0}}));
+  connect(vcvs.Plug1, inductor1.Plug1) annotation(
+    Line(points = {{-60, 0}, {-44, 0}}));
   annotation(
       Documentation(info = "<html><head></head><body><div style=\"font-size: 12px;\">inputs to VCVS_inv:</div><div style=\"font-size: 12px;\">* V_dq;</div><div style=\"font-size: 12px;\">*theta;</div><div style=\"font-size: 12px;\"><br></div><span style=\"font-size: 12px;\">the V_dq and theta input to VCVS are both constants.</span></body></html>"),
       Icon(graphics = {Ellipse(origin = {-55, -2}, extent = {{-27, 26}, {27, -26}}), Line(origin = {-15.52, 1.21}, points = {{-12.8536, -1.20711}, {-12.8536, -1.20711}, {15.1464, -1.20711}, {15.1464, -1.20711}}, thickness = 1), Rectangle(origin = {30, -1}, lineThickness = 0.75, extent = {{-30, 15}, {30, -15}}), Text(origin = {32, -2}, extent = {{-38, 16}, {38, -16}}, textString = "LC"), Line(origin = {79, 0}, points = {{-19, 0}, {19, 0}, {19, 0}}, thickness = 0.75), Line(origin = {-80.8489, -0.170593}, points = {{-19, 0}, {-1, 0}, {-1, 0}}, thickness = 0.75), Rectangle(origin = {54, 56}, lineThickness = 0.5, extent = {{-18, 14}, {12, -8}}), Text(origin = {55, 58}, extent = {{-13, 10}, {7, -6}}, textString = "PLL"), Rectangle(origin = {-20, 58}, extent = {{-70, 10}, {42, -10}}), Text(origin = {-32, 55}, extent = {{-72, 9}, {58, -3}}, textString = "CONTROLLER"), Line(origin = {73, 29}, points = {{7, -29}, {7, 29}, {-7, 29}}, arrow = {Arrow.None, Arrow.Filled}), Line(origin = {29, 58}, points = {{7, 0}, {-7, 0}}, arrow = {Arrow.None, Arrow.Filled}), Line(origin = {-58, 36}, rotation = 180, points = {{0, 12}, {0, -12}, {0, -12}}, thickness = 0.75, arrow = {Arrow.Filled, Arrow.None}), Rectangle(origin = {0, 20}, extent = {{-100, 60}, {100, -60}}), Text(origin = {0, -68}, extent = {{-60, 16}, {60, -16}}, textString = "%name")}, coordinateSystem(initialScale = 0.1)));

--- a/ModPowerSystems/EmtThreePhase/Converters/package.order
+++ b/ModPowerSystems/EmtThreePhase/Converters/package.order
@@ -1,1 +1,2 @@
 InverterPQCtrl
+PQInverter

--- a/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/PQInverterExample.mo
+++ b/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/PQInverterExample.mo
@@ -1,0 +1,26 @@
+within ModPowerSystems.EmtThreePhase.Examples.BasicGrids;
+
+model PQInverterExample
+  Connections.RxLine rxLine1(length = 0.2) annotation(
+    Placement(visible = true, transformation(origin = {46, -12}, extent = {{10, -10}, {-10, 10}}, rotation = 90)));
+  Basics.Ground ground1 annotation(
+    Placement(visible = true, transformation(origin = {-56, -32}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner Base.System system annotation(
+    Placement(visible = true, transformation(origin = {-64, 36}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Loads.ZLoad zLoad1(Pnom = {5e3, 5e3, 5e3}, Qnom = {5e2, 5e2, 5e2}, Vnom = 380) annotation(
+    Placement(visible = true, transformation(origin = {46, -52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  Slack.Slack slack1(Vnom = 380, phiV = 0) annotation(
+    Placement(visible = true, transformation(origin = {46, 32}, extent = {{-10, -10}, {10, 10}}, rotation = 180)));
+  ModPowerSystems.EmtThreePhase.Converters.PQInverter pQInverter annotation(
+    Placement(visible = true, transformation(origin = {-18, -22}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(slack1.Plug1, rxLine1.Plug1) annotation(
+    Line(points = {{46, 22}, {46, -2}}));
+  connect(rxLine1.Plug2, zLoad1.Plug1) annotation(
+    Line(points = {{46, -22}, {46, -22}, {46, -42}, {46, -42}}));
+  connect(ground1.Plug1, pQInverter.Plug1) annotation(
+    Line(points = {{-56, -22}, {-28, -22}}));
+  connect(pQInverter.Plug2, rxLine1.Plug2) annotation(
+    Line(points = {{-8, -22}, {46, -22}}));
+protected
+end PQInverterExample;

--- a/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/Slack_RxLine_ZLoad_InverterPQCtrl.mo
+++ b/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/Slack_RxLine_ZLoad_InverterPQCtrl.mo
@@ -3,7 +3,7 @@ within ModPowerSystems.EmtThreePhase.Examples.BasicGrids;
 model Slack_RxLine_ZLoad_InverterPQCtrl
   ModPowerSystems.EmtThreePhase.Slack.Slack slack1(Vnom = 380, phiV = 0) annotation(
     Placement(visible = true, transformation(origin = {46, 32}, extent = {{-10, -10}, {10, 10}}, rotation = 180)));
-  ModPowerSystems.EmtThreePhase.Connections.RxLine rxLine1(Vnom = 380, length = 0.2) annotation(
+  ModPowerSystems.EmtThreePhase.Connections.RxLine rxLine1(length = 0.2) annotation(
     Placement(visible = true, transformation(origin = {46, -12}, extent = {{10, -10}, {-10, 10}}, rotation = 90)));
   ModPowerSystems.EmtThreePhase.Loads.ZLoad zLoad1(Pnom = {5e3, 5e3, 5e3}, Qnom = {5e2, 5e2, 5e2}, Vnom = 380) annotation(
     Placement(visible = true, transformation(origin = {46, -52}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));

--- a/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/package.order
+++ b/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/package.order
@@ -13,3 +13,4 @@ DER_Feeder
 Microgrid
 VoltageAC_InductionMachine
 SynGen_Park_TPFault_UnitTest_3rdOrderModel
+SynGen_Park_UnitTest_FullModel

--- a/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/package.order
+++ b/ModPowerSystems/EmtThreePhase/Examples/BasicGrids/package.order
@@ -14,3 +14,4 @@ Microgrid
 VoltageAC_InductionMachine
 SynGen_Park_TPFault_UnitTest_3rdOrderModel
 SynGen_Park_UnitTest_FullModel
+PQInverterExample

--- a/ModPowerSystems/EmtThreePhase/Measurements/PLL.mo
+++ b/ModPowerSystems/EmtThreePhase/Measurements/PLL.mo
@@ -8,8 +8,7 @@ extends Modelica.Icons.RotationalSensor;
     Placement(visible = true, transformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   Modelica.Blocks.Interfaces.RealOutput omega annotation(
     Placement(visible = true, transformation(origin = {110, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0), iconTransformation(origin = {110, -40}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  parameter Real f_nom=50;
-  parameter Real omega_nom=2*pi*f_nom;
+  parameter Real omega_nom;
   parameter Real Kp_pll=0.25;
   parameter Real Ki_pll=2;
   parameter Real Kd_pll=1;

--- a/ModPowerSystems/EmtThreePhase/Transforms/DQtoABC_Park.mo
+++ b/ModPowerSystems/EmtThreePhase/Transforms/DQtoABC_Park.mo
@@ -10,5 +10,5 @@ model DQtoABC_Park
 equation
   v_abc =Transforms.Functions.DQtoABC_Park(v_dq, theta);
 annotation (
-    Icon(graphics = {Rectangle(origin = {0, 10}, extent = {{-100, 90}, {100, -90}}), Text(origin = {0, 9}, extent = {{12, -19}, {-8, 13}}, textString = "DQ to ABC", fontSize = 15), Text(origin = {-2, 86}, extent = {{-26, 8}, {26, -8}}, textString = "theta")}, coordinateSystem(initialScale = 0.1)));
+    Icon(graphics = {Rectangle(extent = {{-100, 100}, {100, -100}}), Text(origin = {65, -34}, extent = {{-55, 32}, {21, -46}}, textString = "abc"), Text(origin = {-35, 64}, extent = {{-55, 32}, {21, -46}}, textString = "dq"), Line(origin = {0, 0.636364},points = {{100, 100}, {-100, -100}, {-100, -100}}, thickness = 0.5)}, coordinateSystem(initialScale = 0.1)));
 end DQtoABC_Park;


### PR DESCRIPTION
Add `PQInverter` and `PQInverterControl`.
These classes are the same as `InverterPQCtrl`, but with clear separation of control and electrical circuits into separate classes.